### PR TITLE
Switch to using `flit` for development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        poetry-version: [1.1.4]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -19,10 +18,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
       - name: run tests
         run: |
-          poetry install
-          poetry run pytest
+          pip install '.[test]'
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,21 @@
-[tool.poetry]
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
 name = "evfuncs"
-version = "0.3.2.post1"
 description = "Functions for working with files created by the EvTAF program and the evsonganaly GUI"
-authors = ["David Nicholson <nickledave@users.noreply.github.com>"]
-license = "BSD"
+version = "0.3.2.post1"
+authors = [
+    {name = "David Nicholson", email = "nickledave@users.noreply.github.com"}
+]
+dependencies = [
+    "numpy >=1.18.1",
+    "scipy >=1.2.0",
+]
+requires-python = ">=3.6"
 readme = "README.md"
-repository = "https://github.com/NickleDave/evfuncs"
+license = {file = "LICENSE"}
 classifiers = [
     'License :: OSI Approved :: BSD License',
     'Development Status :: 5 - Production/Stable',
@@ -17,14 +27,10 @@ classifiers = [
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.6"
-numpy = ">=1.18.1"
-scipy = ">=1.2.0"
+[project.optional-dependencies]
+test = [
+    "pytest >=6.2.2"
+]
 
-[tool.poetry.dev-dependencies]
-pytest = ">=6.2.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[project.urls]
+Source = "https://github.com/NickleDave/evfuncs"


### PR DESCRIPTION
- to have PEP 621 metadata in pyproject.toml
- to not need `poetry` and its constraints (e.g. on Python) esp. when writing a conda-forge recipe